### PR TITLE
Add cache array for type weights

### DIFF
--- a/vaporetto/src/lib.rs
+++ b/vaporetto/src/lib.rs
@@ -32,6 +32,7 @@ mod utils;
 mod model;
 mod predictor;
 mod sentence;
+mod type_predictor;
 
 #[cfg(feature = "train")]
 mod feature;
@@ -40,8 +41,6 @@ mod trainer;
 
 #[cfg(feature = "kytea")]
 mod kytea_model;
-
-mod type_predictor;
 
 pub use model::Model;
 pub use predictor::Predictor;

--- a/vaporetto/src/lib.rs
+++ b/vaporetto/src/lib.rs
@@ -41,6 +41,8 @@ mod trainer;
 #[cfg(feature = "kytea")]
 mod kytea_model;
 
+mod type_predictor;
+
 pub use model::Model;
 pub use predictor::Predictor;
 pub use sentence::{BoundaryType, CharacterType, Sentence};

--- a/vaporetto/src/lib.rs
+++ b/vaporetto/src/lib.rs
@@ -32,7 +32,7 @@ mod utils;
 mod model;
 mod predictor;
 mod sentence;
-mod type_predictor;
+mod type_scorer;
 
 #[cfg(feature = "train")]
 mod feature;

--- a/vaporetto/src/predictor.rs
+++ b/vaporetto/src/predictor.rs
@@ -138,10 +138,6 @@ impl Predictor {
         }
     }
 
-    fn add_type_ngram_scores(&self, sentence: &Sentence, start: usize, ys: &mut [ScoreValue]) {
-        self.type_predictor.add_scores(sentence, start, ys);
-    }
-
     fn add_dict_scores(&self, sentence: &Sentence, start: usize, ys: &mut [ScoreValue]) {
         let char_start = if start >= self.dict_window_size {
             start + 1 - self.dict_window_size
@@ -189,7 +185,7 @@ impl Predictor {
     ) {
         ys.fill(self.bias);
         self.add_word_ngram_scores(sentence, range.start, ys);
-        self.add_type_ngram_scores(sentence, range.start, ys);
+        self.type_predictor.add_scores(sentence, range.start, ys);
         self.add_dict_scores(sentence, range.start, ys);
     }
 

--- a/vaporetto/src/predictor.rs
+++ b/vaporetto/src/predictor.rs
@@ -13,7 +13,7 @@ use crossbeam_channel::{Receiver, Sender};
 
 use crate::model::{Model, ScoreValue, WeightValue};
 use crate::sentence::{BoundaryType, Sentence};
-use crate::type_predictor::TypePredictor;
+use crate::type_scorer::TypeScorer;
 
 use daachorse::DoubleArrayAhoCorasick;
 
@@ -28,7 +28,7 @@ pub struct Predictor {
     char_window_size: usize,
     dict_window_size: usize,
 
-    type_predictor: TypePredictor,
+    type_scorer: TypeScorer,
 
     #[cfg(feature = "model-quantize")]
     quantize_multiplier: f64,
@@ -62,7 +62,7 @@ impl Predictor {
         let type_pma = DoubleArrayAhoCorasick::new(model.types).unwrap();
         let dict_pma = DoubleArrayAhoCorasick::new(model.dict).unwrap();
 
-        let type_predictor = TypePredictor::new(type_pma, type_weights, model.type_window_size);
+        let type_scorer = TypeScorer::new(type_pma, type_weights, model.type_window_size);
 
         Self {
             word_pma,
@@ -74,7 +74,7 @@ impl Predictor {
             char_window_size: model.char_window_size,
             dict_window_size: 1,
 
-            type_predictor,
+            type_scorer,
 
             #[cfg(feature = "model-quantize")]
             quantize_multiplier: model.quantize_multiplier,
@@ -185,7 +185,7 @@ impl Predictor {
     ) {
         ys.fill(self.bias);
         self.add_word_ngram_scores(sentence, range.start, ys);
-        self.type_predictor.add_scores(sentence, range.start, ys);
+        self.type_scorer.add_scores(sentence, range.start, ys);
         self.add_dict_scores(sentence, range.start, ys);
     }
 

--- a/vaporetto/src/predictor.rs
+++ b/vaporetto/src/predictor.rs
@@ -13,21 +13,22 @@ use crossbeam_channel::{Receiver, Sender};
 
 use crate::model::{Model, ScoreValue, WeightValue};
 use crate::sentence::{BoundaryType, Sentence};
+use crate::type_predictor::TypePredictor;
+
 use daachorse::DoubleArrayAhoCorasick;
 
 /// Predictor.
 pub struct Predictor {
     word_pma: DoubleArrayAhoCorasick,
-    type_pma: DoubleArrayAhoCorasick,
     dict_pma: DoubleArrayAhoCorasick,
     word_weights: Vec<Vec<ScoreValue>>,
-    type_weights: Vec<Vec<ScoreValue>>,
     dict_weights: Vec<[ScoreValue; 3]>,
     dict_word_wise: bool,
     bias: ScoreValue,
     char_window_size: usize,
-    type_window_size: usize,
     dict_window_size: usize,
+
+    type_predictor: TypePredictor,
 
     #[cfg(feature = "model-quantize")]
     quantize_multiplier: f64,
@@ -60,18 +61,20 @@ impl Predictor {
         let word_pma = DoubleArrayAhoCorasick::new(model.words).unwrap();
         let type_pma = DoubleArrayAhoCorasick::new(model.types).unwrap();
         let dict_pma = DoubleArrayAhoCorasick::new(model.dict).unwrap();
+
+        let type_predictor = TypePredictor::new(type_pma, type_weights, model.type_window_size);
+
         Self {
             word_pma,
-            type_pma,
             dict_pma,
             word_weights,
-            type_weights,
             dict_weights,
             dict_word_wise: model.dict_word_wise,
             bias,
             char_window_size: model.char_window_size,
-            type_window_size: model.type_window_size,
             dict_window_size: 1,
+
+            type_predictor,
 
             #[cfg(feature = "model-quantize")]
             quantize_multiplier: model.quantize_multiplier,
@@ -136,30 +139,7 @@ impl Predictor {
     }
 
     fn add_type_ngram_scores(&self, sentence: &Sentence, start: usize, ys: &mut [ScoreValue]) {
-        let type_start = if start >= self.type_window_size {
-            start + 1 - self.type_window_size
-        } else {
-            0
-        };
-        let type_end = std::cmp::min(
-            start + ys.len() + self.type_window_size,
-            sentence.char_type.len(),
-        );
-        let char_type = &sentence.char_type[type_start..type_end];
-        let padding = start - type_start + 1;
-        for m in self.type_pma.find_overlapping_no_suffix_iter(&char_type) {
-            let offset = m.end() as isize - self.type_window_size as isize - padding as isize;
-            let weights = &self.type_weights[m.pattern()];
-            if offset >= 0 {
-                for (w, y) in weights.iter().zip(&mut ys[offset as usize..]) {
-                    *y += w;
-                }
-            } else {
-                for (w, y) in weights[-offset as usize..].iter().zip(ys.iter_mut()) {
-                    *y += w;
-                }
-            }
-        }
+        self.type_predictor.add_scores(sentence, start, ys);
     }
 
     fn add_dict_scores(&self, sentence: &Sentence, start: usize, ys: &mut [ScoreValue]) {

--- a/vaporetto/src/type_predictor.rs
+++ b/vaporetto/src/type_predictor.rs
@@ -4,6 +4,7 @@ use daachorse::DoubleArrayAhoCorasick;
 
 pub enum TypePredictor {
     Pma(TypePredictorPma),
+    Cache(TypePredictorCache),
 }
 
 impl TypePredictor {
@@ -12,12 +13,17 @@ impl TypePredictor {
         weights: Vec<Vec<ScoreValue>>,
         window_size: usize,
     ) -> Self {
-        Self::Pma(TypePredictorPma::new(pma, weights, window_size))
+        if window_size <= 2 {
+            Self::Cache(TypePredictorCache::new(pma, weights, window_size))
+        } else {
+            Self::Pma(TypePredictorPma::new(pma, weights, window_size))
+        }
     }
 
     pub fn add_scores(&self, sentence: &Sentence, start: usize, ys: &mut [ScoreValue]) {
         match self {
             TypePredictor::Pma(pma) => pma.add_scores(sentence, start, ys),
+            TypePredictor::Cache(cache) => cache.add_scores(sentence, start, ys),
         }
     }
 }
@@ -67,4 +73,132 @@ impl TypePredictorPma {
             }
         }
     }
+}
+
+pub struct TypePredictorCache {
+    scores: Vec<ScoreValue>,
+    window_size: usize,
+    sequence_mask: usize,
+}
+
+impl TypePredictorCache {
+    pub fn new(
+        pma: DoubleArrayAhoCorasick,
+        weights: Vec<Vec<ScoreValue>>,
+        window_size: usize,
+    ) -> Self {
+        let sequence_size = window_size * 2;
+        let all_sequences = ALPHABET_SIZE.pow(sequence_size as u32);
+
+        let mut sequence = vec![0u8; sequence_size];
+        let mut scores = vec![0 as ScoreValue; all_sequences];
+
+        for i in 0..all_sequences {
+            if !Self::seqid_to_seq(i, &mut sequence) {
+                continue;
+            }
+            let mut y = 0;
+            for m in pma.find_overlapping_no_suffix_iter(&sequence) {
+                y += weights[m.pattern()][sequence_size - m.end()];
+            }
+            scores[i] = y;
+        }
+
+        Self {
+            scores,
+            window_size,
+            sequence_mask: (1 << (ALPHABET_SHIFT * sequence_size)) - 1,
+        }
+    }
+
+    pub fn add_scores(&self, sentence: &Sentence, start: usize, ys: &mut [ScoreValue]) {
+        let type_start = if start >= self.window_size {
+            start + 1 - self.window_size
+        } else {
+            0
+        };
+        let type_end = std::cmp::min(
+            start + ys.len() + self.window_size,
+            sentence.char_type.len(),
+        );
+        let char_type = &sentence.char_type[type_start..type_end];
+        let mut seqid = 0;
+        for i in 0..self.window_size {
+            if let Some(ct) = char_type.get(i) {
+                seqid = self.increment_seqid(seqid, *ct);
+            } else {
+                seqid = self.increment_seqid_without_char(seqid);
+            };
+        }
+        for (i, y) in ys.iter_mut().enumerate() {
+            if let Some(ct) = char_type.get(i + self.window_size) {
+                seqid = self.increment_seqid(seqid, *ct);
+            } else {
+                seqid = self.increment_seqid_without_char(seqid);
+            };
+            *y += self.get_score(seqid);
+        }
+    }
+
+    fn seqid_to_seq(mut seqid: usize, sequence: &mut [u8]) -> bool {
+        for i in (0..sequence.len()).rev() {
+            let x = seqid & ALPHABET_MASK;
+            if x == ALPHABET_MASK {
+                return false; // invalid
+            }
+            sequence[i] = ID_TO_TYPE[x];
+            seqid = seqid >> ALPHABET_SHIFT;
+        }
+        assert_eq!(seqid, 0);
+        true
+    }
+
+    #[inline(always)]
+    fn get_score(&self, seqid: usize) -> ScoreValue {
+        self.scores[seqid]
+    }
+
+    #[inline(always)]
+    fn increment_seqid(&self, seqid: usize, char_type: u8) -> usize {
+        let char_id = TYPE_TO_ID[char_type as usize] as usize;
+        debug_assert!(1 <= char_id && char_id <= 6);
+        ((seqid << ALPHABET_SHIFT) | char_id) & self.sequence_mask
+    }
+
+    #[inline(always)]
+    fn increment_seqid_without_char(&self, seqid: usize) -> usize {
+        (seqid << ALPHABET_SHIFT) & self.sequence_mask
+    }
+}
+
+const ALPHABET_SIZE: usize = 8;
+const ALPHABET_MASK: usize = ALPHABET_SIZE - 1;
+const ALPHABET_SHIFT: usize = 3;
+const TYPE_TO_ID: [u32; 256] = make_type_to_id();
+const ID_TO_TYPE: [u8; 256] = make_id_to_type();
+
+const fn make_type_to_id() -> [u32; 256] {
+    use crate::sentence::CharacterType::*;
+
+    let mut type_to_id = [0u32; 256];
+    type_to_id[Digit as usize] = 1;
+    type_to_id[Roman as usize] = 2;
+    type_to_id[Hiragana as usize] = 3;
+    type_to_id[Katakana as usize] = 4;
+    type_to_id[Kanji as usize] = 5;
+    type_to_id[Other as usize] = 6;
+    type_to_id
+}
+
+const fn make_id_to_type() -> [u8; 256] {
+    use crate::sentence::CharacterType::*;
+
+    let mut id_to_type = [0u8; 256];
+    id_to_type[1] = Digit as u8;
+    id_to_type[2] = Roman as u8;
+    id_to_type[3] = Hiragana as u8;
+    id_to_type[4] = Katakana as u8;
+    id_to_type[5] = Kanji as u8;
+    id_to_type[6] = Other as u8;
+    id_to_type
 }

--- a/vaporetto/src/type_predictor.rs
+++ b/vaporetto/src/type_predictor.rs
@@ -1,0 +1,70 @@
+use crate::model::ScoreValue;
+use crate::sentence::Sentence;
+use daachorse::DoubleArrayAhoCorasick;
+
+pub enum TypePredictor {
+    Pma(TypePredictorPma),
+}
+
+impl TypePredictor {
+    pub fn new(
+        pma: DoubleArrayAhoCorasick,
+        weights: Vec<Vec<ScoreValue>>,
+        window_size: usize,
+    ) -> Self {
+        Self::Pma(TypePredictorPma::new(pma, weights, window_size))
+    }
+
+    pub fn add_scores(&self, sentence: &Sentence, start: usize, ys: &mut [ScoreValue]) {
+        match self {
+            TypePredictor::Pma(pma) => pma.add_scores(sentence, start, ys),
+        }
+    }
+}
+
+pub struct TypePredictorPma {
+    pma: DoubleArrayAhoCorasick,
+    weights: Vec<Vec<ScoreValue>>,
+    window_size: usize,
+}
+
+impl TypePredictorPma {
+    pub fn new(
+        pma: DoubleArrayAhoCorasick,
+        weights: Vec<Vec<ScoreValue>>,
+        window_size: usize,
+    ) -> Self {
+        Self {
+            pma,
+            weights,
+            window_size,
+        }
+    }
+
+    pub fn add_scores(&self, sentence: &Sentence, start: usize, ys: &mut [ScoreValue]) {
+        let type_start = if start >= self.window_size {
+            start + 1 - self.window_size
+        } else {
+            0
+        };
+        let type_end = std::cmp::min(
+            start + ys.len() + self.window_size,
+            sentence.char_type.len(),
+        );
+        let char_type = &sentence.char_type[type_start..type_end];
+        let padding = start - type_start + 1;
+        for m in self.pma.find_overlapping_no_suffix_iter(&char_type) {
+            let offset = m.end() as isize - self.window_size as isize - padding as isize;
+            let weights = &self.weights[m.pattern()];
+            if offset >= 0 {
+                for (w, y) in weights.iter().zip(&mut ys[offset as usize..]) {
+                    *y += w;
+                }
+            } else {
+                for (w, y) in weights[-offset as usize..].iter().zip(ys.iter_mut()) {
+                    *y += w;
+                }
+            }
+        }
+    }
+}

--- a/vaporetto/src/type_predictor.rs
+++ b/vaporetto/src/type_predictor.rs
@@ -13,7 +13,7 @@ impl TypePredictor {
         weights: Vec<Vec<ScoreValue>>,
         window_size: usize,
     ) -> Self {
-        if window_size <= 2 {
+        if window_size <= 3 {
             Self::Cache(TypePredictorCache::new(pma, weights, window_size))
         } else {
             Self::Pma(TypePredictorPma::new(pma, weights, window_size))
@@ -122,8 +122,9 @@ impl TypePredictorCache {
             sentence.char_type.len(),
         );
         let char_type = &sentence.char_type[type_start..type_end];
+        let offset = self.window_size + start;
         let mut seqid = 0;
-        for i in 0..self.window_size {
+        for i in 0..offset {
             if let Some(ct) = char_type.get(i) {
                 seqid = self.increment_seqid(seqid, *ct);
             } else {
@@ -131,7 +132,7 @@ impl TypePredictorCache {
             };
         }
         for (i, y) in ys.iter_mut().enumerate() {
-            if let Some(ct) = char_type.get(i + self.window_size) {
+            if let Some(ct) = char_type.get(i + offset) {
                 seqid = self.increment_seqid(seqid, *ct);
             } else {
                 seqid = self.increment_seqid_without_char(seqid);

--- a/vaporetto/src/type_predictor.rs
+++ b/vaporetto/src/type_predictor.rs
@@ -93,7 +93,7 @@ impl TypePredictorCache {
         let mut sequence = vec![0u8; sequence_size];
         let mut scores = vec![0 as ScoreValue; all_sequences];
 
-        for i in 0..all_sequences {
+        for (i, score) in scores.iter_mut().enumerate() {
             if !Self::seqid_to_seq(i, &mut sequence) {
                 continue;
             }
@@ -101,7 +101,7 @@ impl TypePredictorCache {
             for m in pma.find_overlapping_no_suffix_iter(&sequence) {
                 y += weights[m.pattern()][sequence_size - m.end()];
             }
-            scores[i] = y;
+            *score = y;
         }
 
         Self {
@@ -148,7 +148,7 @@ impl TypePredictorCache {
                 return false; // invalid
             }
             sequence[i] = ID_TO_TYPE[x];
-            seqid = seqid >> ALPHABET_SHIFT;
+            seqid >>= ALPHABET_SHIFT;
         }
         assert_eq!(seqid, 0);
         true
@@ -162,12 +162,12 @@ impl TypePredictorCache {
     #[inline(always)]
     fn increment_seqid(&self, seqid: usize, char_type: u8) -> usize {
         let char_id = TYPE_TO_ID[char_type as usize] as usize;
-        debug_assert!(1 <= char_id && char_id <= 6);
+        debug_assert!((1..=6).contains(&char_id));
         ((seqid << ALPHABET_SHIFT) | char_id) & self.sequence_mask
     }
 
     #[inline(always)]
-    fn increment_seqid_without_char(&self, seqid: usize) -> usize {
+    const fn increment_seqid_without_char(&self, seqid: usize) -> usize {
         (seqid << ALPHABET_SHIFT) & self.sequence_mask
     }
 }

--- a/vaporetto/src/type_scorer.rs
+++ b/vaporetto/src/type_scorer.rs
@@ -2,39 +2,39 @@ use crate::model::ScoreValue;
 use crate::sentence::Sentence;
 use daachorse::DoubleArrayAhoCorasick;
 
-pub enum TypePredictor {
-    Pma(TypePredictorPma),
-    Cache(TypePredictorCache),
+pub enum TypeScorer {
+    Pma(TypeScorerPma),
+    Cache(TypeScorerCache),
 }
 
-impl TypePredictor {
+impl TypeScorer {
     pub fn new(
         pma: DoubleArrayAhoCorasick,
         weights: Vec<Vec<ScoreValue>>,
         window_size: usize,
     ) -> Self {
         if window_size <= 3 {
-            Self::Cache(TypePredictorCache::new(pma, weights, window_size))
+            Self::Cache(TypeScorerCache::new(pma, weights, window_size))
         } else {
-            Self::Pma(TypePredictorPma::new(pma, weights, window_size))
+            Self::Pma(TypeScorerPma::new(pma, weights, window_size))
         }
     }
 
     pub fn add_scores(&self, sentence: &Sentence, start: usize, ys: &mut [ScoreValue]) {
         match self {
-            TypePredictor::Pma(pma) => pma.add_scores(sentence, start, ys),
-            TypePredictor::Cache(cache) => cache.add_scores(sentence, start, ys),
+            TypeScorer::Pma(pma) => pma.add_scores(sentence, start, ys),
+            TypeScorer::Cache(cache) => cache.add_scores(sentence, start, ys),
         }
     }
 }
 
-pub struct TypePredictorPma {
+pub struct TypeScorerPma {
     pma: DoubleArrayAhoCorasick,
     weights: Vec<Vec<ScoreValue>>,
     window_size: usize,
 }
 
-impl TypePredictorPma {
+impl TypeScorerPma {
     pub fn new(
         pma: DoubleArrayAhoCorasick,
         weights: Vec<Vec<ScoreValue>>,
@@ -75,13 +75,13 @@ impl TypePredictorPma {
     }
 }
 
-pub struct TypePredictorCache {
+pub struct TypeScorerCache {
     scores: Vec<ScoreValue>,
     window_size: usize,
     sequence_mask: usize,
 }
 
-impl TypePredictorCache {
+impl TypeScorerCache {
     pub fn new(
         pma: DoubleArrayAhoCorasick,
         weights: Vec<Vec<ScoreValue>>,

--- a/vaporetto/src/type_scorer.rs
+++ b/vaporetto/src/type_scorer.rs
@@ -97,7 +97,7 @@ impl TypeScorerCache {
             if !Self::seqid_to_seq(i, &mut sequence) {
                 continue;
             }
-            let mut y = 0;
+            let mut y = ScoreValue::default();
             for m in pma.find_overlapping_no_suffix_iter(&sequence) {
                 y += weights[m.pattern()][sequence_size - m.end()];
             }


### PR DESCRIPTION
I added a cache array that stores weight results for all type sequence patterns. When type_window_size = 3, the array consumes only 1 MiB and can accelerate the tokenization by bypassing pattern matching.

For example, with my environment (GCP, n1-standard-4), the prediction time for `kyoto-train.ja` with `jp-0.4.7-6` model was improved from 4.26 sec to 3.91 sec.

However, this approach uses a large amount of memory for a large type_window_size. So, it is enabled only if type_window_size <= 3. The runtime switching for an input model is implemented with Enum dispatch.